### PR TITLE
Add hook for setProfileManager

### DIFF
--- a/src/fr/mydedibox/hdxposed/Main.java
+++ b/src/fr/mydedibox/hdxposed/Main.java
@@ -4,6 +4,7 @@ import static de.robv.android.xposed.XposedHelpers.*;
 
 import java.lang.reflect.Method;
 
+import android.content.Context;
 import android.content.ContentValues;
 import android.content.pm.PackageManager;
 import android.content.res.XResources;
@@ -115,6 +116,23 @@ public class Main implements IXposedHookLoadPackage, IXposedHookZygoteInit
     	{
     		log( t );
     	}
+    	
+        // setProfileManager
+        try {
+            final Class<?> cls = findClass("android.content.ContextWrapper", null);
+            final Method m = findMethodExact(cls, "setProfileManager", Context.class);
+
+            XposedBridge.hookMethod(m, new XC_MethodReplacement() {
+                @Override
+                protected Object replaceHookedMethod(MethodHookParam param) throws Throwable {
+                    return null;
+                }
+            });
+
+            log(cls.getName() + "." + m.getName() + " hooked");
+        } catch (Throwable t) {
+            log(t);
+        }
 	}
 	
 	@Override


### PR DESCRIPTION
tl;dr: This enables the use of the latest version of Google Play Services on the Kindle Fire HDX 7" and firmware 13.3.2.8. Others may work as well.

This prevents a NullPointerException from being thrown when calling setProfileManager. This prevents the latest versions of Google Play Services (8.3.0.0 to precise) from starting.

I retrieved the following callstack from my Kindle Fire HDX 7", firmware 13.3.2.8:

```
E/AndroidRuntime(17785): java.lang.RuntimeException: Unable to instantiate application com.google.android.gms.common.app.GmsApplication: java.lang.NullPointerException
E/AndroidRuntime(17785):    at android.app.LoadedApk.makeApplication(LoadedApk.java:514)
E/AndroidRuntime(17785):    at android.app.ActivityThread.handleBindApplication(ActivityThread.java:4509)
E/AndroidRuntime(17785):    at de.robv.android.xposed.XposedBridge.invokeOriginalMethodNative(Native Method)
E/AndroidRuntime(17785):    at de.robv.android.xposed.XposedBridge.handleHookedMethod(XposedBridge.java:631)
E/AndroidRuntime(17785):    at android.app.ActivityThread.handleBindApplication(Native Method)
E/AndroidRuntime(17785):    at android.app.ActivityThread.access$1300(ActivityThread.java:149)
E/AndroidRuntime(17785):    at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1308)
E/AndroidRuntime(17785):    at android.os.Handler.dispatchMessage(Handler.java:99)
E/AndroidRuntime(17785):    at android.os.Looper.loop(Looper.java:151)
E/AndroidRuntime(17785):    at android.app.ActivityThread.main(ActivityThread.java:5185)
E/AndroidRuntime(17785):    at java.lang.reflect.Method.invokeNative(Native Method)
E/AndroidRuntime(17785):    at java.lang.reflect.Method.invoke(Method.java:511)
E/AndroidRuntime(17785):    at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:793)
E/AndroidRuntime(17785):    at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:560)
E/AndroidRuntime(17785):    at de.robv.android.xposed.XposedBridge.main(XposedBridge.java:132)
E/AndroidRuntime(17785):    at dalvik.system.NativeStart.main(Native Method)

E/AndroidRuntime(17785): Caused by: java.lang.NullPointerException
E/AndroidRuntime(17785):    at android.content.ContextWrapper.getSystemService(ContextWrapper.java:522)
E/AndroidRuntime(17785):    at android.content.ContextWrapper.setProfileManager(ContextWrapper.java:88)
E/AndroidRuntime(17785):    at android.content.ContextWrapper.<init>(ContextWrapper.java:63)
E/AndroidRuntime(17785):    at com.google.android.gms.common.app.BaseApplicationContext.<init>(SourceFile:38)
E/AndroidRuntime(17785):    at com.google.android.gms.common.app.BaseApplicationContext.<init>(SourceFile:34)
E/AndroidRuntime(17785):    at com.google.android.gms.common.app.a.<init>(SourceFile:28)
E/AndroidRuntime(17785):    at com.google.android.gms.common.app.GmsApplication.<init>(SourceFile:57)
E/AndroidRuntime(17785):    at java.lang.Class.newInstanceImpl(Native Method)
E/AndroidRuntime(17785):    at java.lang.Class.newInstance(Class.java:1319)
E/AndroidRuntime(17785):    at android.app.Instrumentation.newApplication(Instrumentation.java:983)
E/AndroidRuntime(17785):    at android.app.Instrumentation.newApplication(Instrumentation.java:968)
E/AndroidRuntime(17785):    at android.app.LoadedApk.makeApplication(LoadedApk.java:509)
E/AndroidRuntime(17785):    ... 15 more
```

After dexing, smalling, baksmalling, jarring, and tracing, I came up with the following function bodies for the top few calls in the stacktrace:

```
  public Object getSystemService(String paramString)
  {
    return this.mBase.getSystemService(paramString);
  }

  private void setProfileManager(Context paramContext)
  {
    if ((paramContext != null) && (TLoggerFactory.getProfileManager() == null)) {
      TLoggerFactory.setProfileManager((ProfileManager)paramContext.getSystemService("amazontracingservice"));
    }
  }

  public ContextWrapper(Context paramContext)
  {
    this.mBase = paramContext;
    setProfileManager(paramContext);
  }
```

I'm not sure why `this.mBase` would be `null`, but that's what seems to be happening. Luckily, `setProfileManager` seems to be doing something mildly nefarious, so I just null'd out the function call altogether. It doesn't seem to have had any adverse affects on my kindle, so I'm calling this a win =)
